### PR TITLE
Update 04_encounter.Rmd

### DIFF
--- a/04_encounter.Rmd
+++ b/04_encounter.Rmd
@@ -21,6 +21,7 @@ Let's get started by loading the necessary packages and data. If you worked thro
 ```{r encounter-data}
 library(sf)
 library(raster)
+remotes::install_github("r-barnes/dggridR")
 library(dggridR)
 library(lubridate)
 library(ranger)


### PR DESCRIPTION
dggridR has not been maintained for many years and is not available on CRAN currently. It must be installed via: remotes::install_github("r-barnes/dggridR"). The package compilation takes a long time and the process must not be quitted.